### PR TITLE
Fix missing PATH config for cron schedule

### DIFF
--- a/lib/templates/erb/whenever_schedule.rb.erb
+++ b/lib/templates/erb/whenever_schedule.rb.erb
@@ -7,6 +7,8 @@
 set :environment, '<%= Rails.env %>'
 set :output, '<%= Rails.application.config.benchmark_schedule_log %>'
 
+env :PATH, '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games'
+
 production_env = 'BUNDLE_GEMFILE=<%= File.join(Rails.root, 'Gemfile') %>'
 job_type :runner,  "cd :path && #{production_env if @environment == 'production'} :runner_command -e :environment ':task' :output"
 


### PR DESCRIPTION
Scheduled benchmarks failed with the error message `/usr/bin/env: ruby: No such file or directory`.
This was caused by the new installation procedure where Ruby is symlinked into `/usr/local/bin`.

Cron does not run with the same PATH as usually logged in users.
Therefore, whenever must explicitly specify the PATH, including `/usr/local/bin`.