### PR TITLE
Fix libv8 compile issue on MacOS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem 'font-awesome-rails', '~> 4.5.0.1'
 gem 'will_paginate', '~> 3.1.0'
 gem 'bootstrap-will_paginate', '~> 0.0.10'
 gem 'simple_form', '~> 3.2.1'
-gem 'data-confirm-modal', github: 'ifad/data-confirm-modal'
+gem 'data-confirm-modal', '~> 1.3'
 
 # Admin
 gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: git://github.com/ifad/data-confirm-modal.git
-  revision: a2018ab8893cdeeeffaae407368ed1a20ea72b30
-  specs:
-    data-confirm-modal (1.1.0)
-      railties (>= 3.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -77,6 +70,8 @@ GEM
     concurrent-ruby (1.0.1)
     cron2english (0.1.6)
     daemons (1.2.3)
+    data-confirm-modal (1.3.0)
+      railties (>= 3.0)
     database_cleaner (1.5.1)
     debug_inspector (0.0.2)
     deep_cloneable (2.2.0)
@@ -164,7 +159,7 @@ GEM
       less (~> 2.6.0)
       sprockets (> 2, < 4)
       tilt
-    libv8 (3.16.14.13)
+    libv8 (3.16.14.19)
     listen (3.0.6)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9.7)
@@ -331,7 +326,7 @@ DEPENDENCIES
   capybara (~> 2.6.2)
   coffee-rails (~> 4.1.1)
   cron2english (~> 0.1.3)
-  data-confirm-modal!
+  data-confirm-modal (~> 1.3)
   database_cleaner (~> 1.5.0)
   deep_cloneable (~> 2.2.0)
   delayed_job_active_record (~> 4.1)
@@ -376,5 +371,8 @@ DEPENDENCIES
   will_paginate (~> 3.1.0)
   yard (~> 0.8.7.6)
 
+RUBY VERSION
+   ruby 2.2.4p230
+
 BUNDLED WITH
-   1.11.2
+   1.14.6


### PR DESCRIPTION
* Couldn't install the `libv8` gem as part of `therubyracer` dependency
  because compiling native extensions failed. Bumping the version solved this issue.
* Use the newly released version (2017-01-17) of the `data-confirm-modal` gem:
  https://rubygems.org/gems/data-confirm-modal/versions/1.3.0