### PR TITLE
Fix HTTP status codes for errors

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -5,7 +5,7 @@ class ErrorsController < ApplicationController
   # layout 'errors'
 
   def show
-    render status: status, template: "errors/#{status_code}", formats: [:html]
+    render status: status_code, template: "errors/#{status_code}", formats: [:html]
   end
 
   protected


### PR DESCRIPTION
Problem: Errors (i.e., 404, 422, 500) returned 200 by mistake

Solution: Return the right error code by calling the right helper method