### PR TITLE
Fix travis build by pinning to older distro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: ruby
 script:
   - bin/rake


### PR DESCRIPTION
See: https://travis-ci.community/t/bundle-install-started-failing-on-ruby-build/4368

Background: https://bundler.io/blog/2019/05/14/solutions-for-cant-find-gem-bundler-with-executable-bundle.html